### PR TITLE
fix: exclude admin and academic_associate roles from attendance Disco…

### DIFF
--- a/src/services/attendanceTrackingService.ts
+++ b/src/services/attendanceTrackingService.ts
@@ -319,11 +319,12 @@ export class AttendanceTrackingService {
       const snapshot = await getDocs(studentsQuery);
       let students = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() } as User));
 
-      // Filter by status and campus
+      // Filter by status, campus, and role (exclude admin and academic_associate)
       students = students.filter(student => {
         const isActive = !student.status || student.status === 'active';
         const matchesCampus = !campus || student.campus === campus;
-        return isActive && matchesCampus;
+        const isNotAdminRole = student.role !== 'admin' && student.role !== 'academic_associate';
+        return isActive && matchesCampus && isNotAdminRole;
       });
 
       return students;


### PR DESCRIPTION
**Problem**
Admin and Academic Associate users were being included in the daily attendance tracking and appearing as "absent" in Discord reports when they didn't submit daily goals. These roles are administrative/support roles and shouldn't be tracked for daily attendance.

**Solution**
Updated the [getActiveStudents()](vscode-file://vscode-app/c:/Users/sachi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) method in [attendanceTrackingService.ts](vscode-file://vscode-app/c:/Users/sachi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to filter out users with admin and academic_associate roles from attendance tracking.

**Changes Made**
Modified attendanceTrackingService.ts
Added role-based filtering in the getActiveStudents() method
Now excludes users where [role === 'admin'] or [role === 'academic_associate']

These users will no longer appear in:
Total student count
Absent students list in Discord reports
Daily attendance statistics

**Testing**
 Verify Discord attendance reports no longer list admin/academic associate users as absent
 Confirm attendance percentage calculations exclude these roles
 Check that regular students are still tracked correctly

**Impact**
Cleaner, more accurate attendance reports in Discord
Better attendance rate calculations that only include actual students
Reduces noise in daily reports