### PR TITLE
Fix leave status priority and add unapproved_leave status

### DIFF
--- a/src/components/Admin/AdminUserManagement.tsx
+++ b/src/components/Admin/AdminUserManagement.tsx
@@ -30,7 +30,7 @@ const AdminUserManagement: React.FC = () => {
   const [updating, setUpdating] = useState<string | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState<string | null>(null);
   const [showStatusModal, setShowStatusModal] = useState<string | null>(null);
-  const [selectedStatus, setSelectedStatus] = useState<'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave'>('active');
+  const [selectedStatus, setSelectedStatus] = useState<'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave' | 'unapproved_leave'>('active');
   const [showRoleModal, setShowRoleModal] = useState<boolean>(false);
   const [selectedRole, setSelectedRole] = useState<'admin' | 'academic_associate' | 'super_mentor' | 'mentor' | 'student'>('student');
   const [selectedUser, setSelectedUser] = useState<any>(null);
@@ -89,15 +89,24 @@ const AdminUserManagement: React.FC = () => {
     }
   };
 
-  const handleUpdateStatus = async (userId: string, newStatus: 'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave') => {
+  const handleUpdateStatus = async (userId: string, newStatus: 'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave' | 'unapproved_leave') => {
     try {
       setUpdating(userId);
       await AdminService.updateUserStatus(userId, newStatus);
       
-      // Update local state
-      setUsers(users.map(user => 
-        user.id === userId ? { ...user, status: newStatus } : user
-      ));
+      // Update local state with the new status and unapproved_leave_start if applicable
+      setUsers(users.map(user => {
+        if (user.id === userId) {
+          const updatedUser = { ...user, status: newStatus };
+          if (newStatus === 'unapproved_leave') {
+            updatedUser.unapproved_leave_start = new Date();
+          } else {
+            updatedUser.unapproved_leave_start = undefined;
+          }
+          return updatedUser;
+        }
+        return user;
+      }));
       
       setShowStatusModal(null);
     } catch (error) {
@@ -152,6 +161,7 @@ const AdminUserManagement: React.FC = () => {
       case 'placed': return <Award className="h-4 w-4 text-purple-500" />;
       case 'on_leave': return <Clock className="h-4 w-4 text-orange-500" />;
       case 'kitchen_leave': return <Clock className="h-4 w-4 text-blue-500" />;
+      case 'unapproved_leave': return <Clock className="h-4 w-4 text-red-600" />;
       default: return <CheckCircle className="h-4 w-4 text-green-500" />;
     }
   };
@@ -164,6 +174,7 @@ const AdminUserManagement: React.FC = () => {
       case 'placed': return 'Placed';
       case 'on_leave': return 'On Leave';
       case 'kitchen_leave': return 'Kitchen Leave';
+      case 'unapproved_leave': return 'Unapproved Leave';
       default: return 'Active';
     }
   };
@@ -176,6 +187,7 @@ const AdminUserManagement: React.FC = () => {
       case 'placed': return 'bg-purple-100 text-purple-800';
       case 'on_leave': return 'bg-orange-100 text-orange-800';
       case 'kitchen_leave': return 'bg-blue-100 text-blue-800';
+      case 'unapproved_leave': return 'bg-red-100 text-red-900';
       default: return 'bg-green-100 text-green-800';
     }
   };
@@ -675,7 +687,7 @@ const AdminUserManagement: React.FC = () => {
               </label>
               <select
                 value={selectedStatus}
-                onChange={(e) => setSelectedStatus(e.target.value as 'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave')}
+                onChange={(e) => setSelectedStatus(e.target.value as 'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave' | 'unapproved_leave')}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               >
                 <option value="active">Active</option>
@@ -684,6 +696,7 @@ const AdminUserManagement: React.FC = () => {
                 <option value="placed">Placed</option>
                 <option value="on_leave">On Leave</option>
                 <option value="kitchen_leave">Kitchen Leave</option>
+                <option value="unapproved_leave">Unapproved Leave</option>
               </select>
             </div>
             <div className="flex justify-end space-x-3">

--- a/src/services/dataServices.ts
+++ b/src/services/dataServices.ts
@@ -916,12 +916,22 @@ export class AdminService extends FirestoreService {
   }
 
   // Update user status
-  static async updateUserStatus(userId: string, status: 'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave'): Promise<void> {
+  static async updateUserStatus(userId: string, status: 'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave' | 'unapproved_leave'): Promise<void> {
     try {
-      return await this.update<any>(COLLECTIONS.USERS, userId, { 
+      const updateData: any = { 
         status,
         updated_at: new Date()
-      });
+      };
+      
+      // If changing to unapproved_leave, record the date
+      if (status === 'unapproved_leave') {
+        updateData.unapproved_leave_start = new Date();
+      } else {
+        // Clear unapproved_leave_start when changing to any other status
+        updateData.unapproved_leave_start = null;
+      }
+      
+      return await this.update<any>(COLLECTIONS.USERS, userId, updateData);
     } catch (error) {
       console.error('Error updating user status:', error);
       throw error;

--- a/src/services/discordService.ts
+++ b/src/services/discordService.ts
@@ -568,9 +568,12 @@ export class DiscordService {
     attendanceRate: number,
     studentsOnKitchenLeave: number,
     studentsOnRegularLeave: number,
+    studentsOnUnapprovedLeave: number,
     absentStudentsList: string[],
     kitchenLeaveStudentsList: string[],
     regularLeaveStudentsList: string[],
+    unapprovedLeaveStudentsList: string[],
+    unapprovedLeaveDetails: { name: string; startDate: string }[],
     campus?: string
   ): Promise<void> {
     const webhookUrl = campus ? await this.getCampusWebhook(campus) : this.WEBHOOK_URL;
@@ -603,6 +606,14 @@ export class DiscordService {
     
     const moreRegularLeave = regularLeaveStudentsList.length > 30
       ? `\n_...and ${regularLeaveStudentsList.length - 30} more_`
+      : '';
+
+    const unapprovedLeaveList = unapprovedLeaveDetails.length > 0
+      ? unapprovedLeaveDetails.slice(0, 20).map(u => `${u.name} (since ${u.startDate})`).join(', ')
+      : 'None';
+    
+    const moreUnapprovedLeave = unapprovedLeaveDetails.length > 20
+      ? `\n_...and ${unapprovedLeaveDetails.length - 20} more_`
       : '';
 
     // Choose color based on attendance rate
@@ -643,7 +654,12 @@ export class DiscordService {
           inline: false,
         },
         {
-          name: '📈 Attendance Rate',
+          name: '� Unapproved Leave',
+          value: `${studentsOnUnapprovedLeave} students`,
+          inline: false,
+        },
+        {
+          name: '�📈 Attendance Rate',
           value: `${attendanceRate.toFixed(1)}%`,
           inline: false,
         },
@@ -660,6 +676,11 @@ export class DiscordService {
         {
           name: '🏖️ On Leave Students',
           value: regularLeaveList + moreRegularLeave,
+          inline: false,
+        },
+        {
+          name: '🚨 Unapproved Leave Students',
+          value: unapprovedLeaveList + moreUnapprovedLeave,
           inline: false,
         },
       ],
@@ -686,9 +707,12 @@ export class DiscordService {
     attendanceRate: number,
     studentsOnKitchenLeave: number,
     studentsOnRegularLeave: number,
+    studentsOnUnapprovedLeave: number,
     absentStudentsList: string[],
     kitchenLeaveStudentsList: string[],
-    regularLeaveStudentsList: string[]
+    regularLeaveStudentsList: string[],
+    unapprovedLeaveStudentsList: string[],
+    unapprovedLeaveDetails: { name: string; startDate: string }[]
   ): Promise<void> {
     await this.sendAttendanceReport(
       date,
@@ -698,9 +722,12 @@ export class DiscordService {
       attendanceRate,
       studentsOnKitchenLeave,
       studentsOnRegularLeave,
+      studentsOnUnapprovedLeave,
       absentStudentsList,
       kitchenLeaveStudentsList,
       regularLeaveStudentsList,
+      unapprovedLeaveStudentsList,
+      unapprovedLeaveDetails,
       campus
     );
   }

--- a/src/services/leaveScheduler.ts
+++ b/src/services/leaveScheduler.ts
@@ -38,7 +38,10 @@ export class LeaveScheduler {
     try {
       console.log('Checking for expired leaves...');
       
-      // Expire kitchen leaves (auto-changes status to active)
+      // Activate future leaves that have started
+      await LeaveManagementService.activateFutureLeaves();
+      
+      // Expire kitchen leaves (auto-changes status to active or next active leave)
       await LeaveManagementService.expireKitchenLeaves();
       
       // Check and notify for expired on leaves (doesn't auto-change status)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,9 +37,10 @@ export interface User {
   campus?: 'Dantewada' | 'Dharamshala' | 'Eternal' | 'Jashpur' | 'Kishanganj' | 'Pune' | 'Raigarh' | 'Sarjapura' | 'Bageshree' | 'Malhar' | 'Bhairav';  // User's campus or house
   current_phase_id?: string;  // Current phase the user is on
   current_phase_name?: string;  // Denormalized phase name for display
-  status?: 'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave';  // User's current status
+  status?: 'active' | 'inactive' | 'dropout' | 'placed' | 'on_leave' | 'kitchen_leave' | 'unapproved_leave';  // User's current status
   leave_from?: Date;  // Start date of leave period
   leave_to?: Date;    // End date of leave period
+  unapproved_leave_start?: Date;  // Date when unapproved leave started (when on_leave expired)
   campus_joining_date?: Date; // Date when student joined the campus
   deleted_at?: Date;  // Soft delete timestamp
   created_at: Date;


### PR DESCRIPTION
- Fix: Kitchen leave expiry now checks for active on_leave before setting status to active
- Add: New 'unapproved_leave' status for expired on_leave
- Add: Automatic status change to unapproved_leave when on_leave expires
- Add: unapproved_leave_start field to track when unapproved leave began
- Add: unapproved_leave option in admin user management dropdown
- Add: Discord attendance reports now include unapproved leave count and details
- Fix: User status takes priority over leave records in attendance tracking
- Fix: Include unapproved_leave students in active students list
- Fix: Proper date formatting with year for unapproved leave display
- Add: Helper function updateUserStatusFromActiveLeaves for consistent status management
- Add: activateFutureLeaves function to set status when approved leaves start