### PR TITLE
Fix: Include admins and academic associates in mentor assignment list

### DIFF
--- a/src/services/dataServices.ts
+++ b/src/services/dataServices.ts
@@ -1015,12 +1015,13 @@ export class AdminService extends FirestoreService {
     }
   }
 
-  // Get potential mentors (students who can mentor others)
+  // Get potential mentors (students, admins, and academic associates who can mentor others)
   static async getPotentialMentors(): Promise<any[]> {
     try {
       const allUsers = await this.getAllUsers();
-      // Return all non-admin users who could potentially be mentors
-      return allUsers.filter(user => !user.isAdmin);
+      // Return all users including admins and academic associates
+      // Everyone can potentially be a mentor now
+      return allUsers;
     } catch (error) {
       console.error('Error getting potential mentors:', error);
       throw error;


### PR DESCRIPTION
Problem
In the mentor management section, admins and academic associates were not appearing in the list of potential mentors. This prevented admins from assigning admins or academic associates as mentors to students.

Solution
Modified the [getPotentialMentors()](vscode-file://vscode-app/c:/Users/sachi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) method in [dataServices.ts](vscode-file://vscode-app/c:/Users/sachi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to include all users (students, admins, and academic associates) as potential mentors, rather than filtering out admin users.

Changes
File: [dataServices.ts](vscode-file://vscode-app/c:/Users/sachi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Method: [AdminService.getPotentialMentors()](vscode-file://vscode-app/c:/Users/sachi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Change: Removed the filter that excluded users with [isAdmin: true](vscode-file://vscode-app/c:/Users/sachi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Before: 
return allUsers.filter(user => !user.isAdmin);

After
return allUsers;

Impact
Admins can now assign other admins as mentors
Academic associates can be assigned as mentors
All users are visible in the mentor assignment interface
No breaking changes to existing functionality
Testing
✅ Verify admins appear in suggested mentors list
✅ Verify academic associates appear in suggested mentors list
✅ Verify mentor assignment still works for regular students
✅ Verify phase-based mentor suggestions still function correctly